### PR TITLE
Remove "Must be unique within the domain" from id descriptions

### DIFF
--- a/model/Provenance.html
+++ b/model/Provenance.html
@@ -292,7 +292,7 @@
                     </tr>
                     <tr>
                       <td class="feature-heading">description</td>
-                      <td class="feature-detail">Unique identifier for an Activity. Must be unique in the domain.</td>
+                      <td class="feature-detail">Unique identifier for an Activity.</td>
                     </tr>
                     <tr>
                       <td class="feature-detail" valign="top" rowspan="4"><a name="Activity.name"></a><b>name</b></td>
@@ -766,7 +766,7 @@
                     </tr>
                     <tr>
                       <td class="feature-heading">description</td>
-                      <td class="feature-detail">Unique identifier for an Agent. Must be unique in the domain.</td>
+                      <td class="feature-detail">Unique identifier for an Agent.</td>
                     </tr>
                     <tr>
                       <td class="feature-detail" valign="top" rowspan="4"><a name="Agent.name"></a><b>name</b></td>
@@ -1173,7 +1173,7 @@
                     </tr>
                     <tr>
                       <td class="feature-heading">description</td>
-                      <td class="feature-detail">Unique identifier for an Entity. Must be unique in the domain.
+                      <td class="feature-detail">Unique identifier for an Entity.
                         
                       </td>
                     </tr>
@@ -3073,7 +3073,7 @@
       <tr>
         <td class="feature-detail"><a href="#Activity.id">Activity.id</a></td>
         <td class="feature-detail">attribute</td>
-        <td class="feature-detail">Unique identifier for an Activity. Must be unique in the domain.</td>
+        <td class="feature-detail">Unique identifier for an Activity.</td>
       </tr>
       <tr>
         <td class="feature-detail"><a href="#Activity.informant">Activity.informant</a></td>
@@ -3194,7 +3194,7 @@
       <tr>
         <td class="feature-detail"><a href="#Agent.id">Agent.id</a></td>
         <td class="feature-detail">attribute</td>
-        <td class="feature-detail">Unique identifier for an Agent. Must be unique in the domain.</td>
+        <td class="feature-detail">Unique identifier for an Agent.</td>
       </tr>
       <tr>
         <td class="feature-detail"><a href="#Agent.name">Agent.name</a></td>
@@ -3293,7 +3293,7 @@
       <tr>
         <td class="feature-detail"><a href="#Entity.id">Entity.id</a></td>
         <td class="feature-detail">attribute</td>
-        <td class="feature-detail">Unique identifier for an Entity. Must be unique in the domain.
+        <td class="feature-detail">Unique identifier for an Entity.
           
         </td>
       </tr>

--- a/model/Provenance.vo-dml.xml
+++ b/model/Provenance.vo-dml.xml
@@ -48,7 +48,7 @@
     <attribute>
       <vodml-id>Agent.id</vodml-id>
       <name>id</name>
-      <description>Unique identifier for an Agent. Must be unique in the domain.</description>
+      <description>Unique identifier for an Agent.</description>
       <datatype>
         <vodml-ref>ivoa:string</vodml-ref>
       </datatype>
@@ -224,7 +224,7 @@ The method applied for this task is described in the ActivityDescription class a
     <attribute>
       <vodml-id>Activity.id</vodml-id>
       <name>id</name>
-      <description>Unique identifier for an Activity. Must be unique in the domain.</description>
+      <description>Unique identifier for an Activity.</description>
       <datatype>
         <vodml-ref>ivoa:string</vodml-ref>
       </datatype>
@@ -407,7 +407,7 @@ This is might help to check dependencies and errors into the database.</descript
     <attribute>
       <vodml-id>Entity.id</vodml-id>
       <name>id</name>
-      <description>Unique identifier for an Entity. Must be unique in the domain.
+      <description>Unique identifier for an Entity.
 </description>
       <datatype>
         <vodml-ref>ivoa:string</vodml-ref>

--- a/model/Provenance.xmi
+++ b/model/Provenance.xmi
@@ -376,7 +376,7 @@ Attribute "artefactType" holds the type of its target .</body>
       </ownedComment>
       <ownedAttribute xmi:type="uml:Property" xmi:id="_nJHarQxREeqqANoucpOeuQ" name="id" visibility="public" type="_nJGzPgxREeqqANoucpOeuQ" isUnique="false">
         <ownedComment xmi:type="uml:Comment" xmi:id="_nJHargxREeqqANoucpOeuQ">
-          <body>Unique identifier for an Agent. Must be unique in the domain.</body>
+          <body>Unique identifier for an Agent.</body>
         </ownedComment>
       </ownedAttribute>
       <ownedAttribute xmi:type="uml:Property" xmi:id="_nJHarwxREeqqANoucpOeuQ" name="name" visibility="public" type="_nJGzPgxREeqqANoucpOeuQ" isUnique="false">
@@ -513,7 +513,7 @@ The method applied for this task is described in the ActivityDescription class a
       </ownedAttribute>
       <ownedAttribute xmi:type="uml:Property" xmi:id="_nJHa8QxREeqqANoucpOeuQ" name="id" visibility="public" type="_nJGzPgxREeqqANoucpOeuQ" isUnique="false">
         <ownedComment xmi:type="uml:Comment" xmi:id="_nJHa8gxREeqqANoucpOeuQ">
-          <body>Unique identifier for an Activity. Must be unique in the domain.</body>
+          <body>Unique identifier for an Activity.</body>
         </ownedComment>
       </ownedAttribute>
       <ownedAttribute xmi:type="uml:Property" xmi:id="_nJHa8wxREeqqANoucpOeuQ" name="name" visibility="public" type="_nJGzPgxREeqqANoucpOeuQ" isUnique="false">
@@ -634,7 +634,7 @@ This is might help to check dependencies and errors into the database.</body>
       </ownedAttribute>
       <ownedAttribute xmi:type="uml:Property" xmi:id="_nJHbMAxREeqqANoucpOeuQ" name="id" visibility="public" type="_nJGzPgxREeqqANoucpOeuQ" isUnique="false">
         <ownedComment xmi:type="uml:Comment" xmi:id="_nJHbMQxREeqqANoucpOeuQ">
-          <body>Unique identifier for an Entity. Must be unique in the domain.
+          <body>Unique identifier for an Entity.
 </body>
         </ownedComment>
       </ownedAttribute>


### PR DESCRIPTION
This text does not appear in the PDF version of the document. It may be misleading as the other appearance of "domain" in the model is "the domain of astronomy".

It is always a good idea to keep PDF and model identical, also with the descriptions.

Fixes #5 