### PR TITLE
correct VO-DML for SubsettedRole

### DIFF
--- a/model/Provenance.vo-dml.xml
+++ b/model/Provenance.vo-dml.xml
@@ -602,10 +602,10 @@ Allows coarse description of the provenance.</description>
     </extends>
     <constraint xsi:type="vo-dml:SubsettedRole">
       <role>
-        <vodml-ref>Provenance:ValueEntity</vodml-ref>
+        <vodml-ref>voprov:Entity.entityDescription</vodml-ref>
       </role>
       <datatype>
-        <vodml-ref>Provenance:ValueDescription</vodml-ref>
+        <vodml-ref>voprov:ValueDescription</vodml-ref>
       </datatype>
     </constraint>
     <attribute>
@@ -631,10 +631,10 @@ Allows coarse description of the provenance.</description>
     </extends>
     <constraint xsi:type="vo-dml:SubsettedRole">
       <role>
-        <vodml-ref>Provenance:DatasetEntity</vodml-ref>
+        <vodml-ref>voprov:Entity.entityDescription</vodml-ref>
       </role>
       <datatype>
-        <vodml-ref>Provenance:DatasetDescription</vodml-ref>
+        <vodml-ref>voprov:DatasetDescription</vodml-ref>
       </datatype>
     </constraint>
   </objectType>


### PR DESCRIPTION
The VO-DML was invalid because the Subsetting was not done properly - I believe that the changes made reflect the intention of the original authors, however, they should check